### PR TITLE
Use empty tag

### DIFF
--- a/src/sphinx_inline_tabs/_impl.py
+++ b/src/sphinx_inline_tabs/_impl.py
@@ -25,7 +25,11 @@ class _GeneralHTMLTagElement(nodes.Element, nodes.General):
         attributes.pop("dupnames")
         attributes.pop("backrefs")
 
-        text = translator.starttag(node, node._tagname, **attributes)
+        if node._endtag:
+            text = translator.starttag(node, node._tagname, **attributes)
+        else:
+            text = translator.emptytag(node, node._tagname, **attributes)
+
         translator.body.append(text.strip())
 
     @staticmethod


### PR DESCRIPTION
Unpaired tags must be closed with `/>`, this breaks epub output:

```html
<input checked="True" class="tab-input" id="tab-set--0-input--1" name="tab-set--0" type="radio">
```

In the tests this is correct, but they're parsed by beatifulsoup, so this might not be detected properly.